### PR TITLE
增加方法跳过对org.chromium.content.app.SandboxedProcessService0的检查，解决高版本内置更新报错

### DIFF
--- a/app/src/main/java/com/norman/webviewup/demo/MainActivity.java
+++ b/app/src/main/java/com/norman/webviewup/demo/MainActivity.java
@@ -126,7 +126,12 @@ public class MainActivity extends Activity implements UpgradeCallback {
                         "org.bromite.webview",
                         "108.0.5359.156",
                         "",
-                        "安装包")
+                        "安装包"),
+                new UpgradeInfo(
+                        "com.android.webview",
+                        "109.5.5414.123",
+                        "webview-x86.apk",
+                        "内置")
         ));
 
     }

--- a/core/src/main/java/com/norman/webviewup/lib/service/proxy/PackageManagerProxy.java
+++ b/core/src/main/java/com/norman/webviewup/lib/service/proxy/PackageManagerProxy.java
@@ -2,6 +2,7 @@ package com.norman.webviewup.lib.service.proxy;
 
 import android.content.ComponentName;
 import android.content.pm.PackageInfo;
+import android.content.pm.ServiceInfo;
 
 import com.norman.webviewup.lib.reflect.RuntimeProxy;
 import com.norman.webviewup.lib.reflect.annotation.ClassName;
@@ -15,6 +16,8 @@ public abstract class PackageManagerProxy extends RuntimeProxy {
         super();
     }
 
+    @Method("getServiceInfo")
+    protected abstract ServiceInfo getServiceInfo(ComponentName componentName, long flags, int userId);
 
     @Method("getPackageInfo")
     protected abstract PackageInfo getPackageInfo(String packageName, long flags, int userId);


### PR DESCRIPTION
解決“Illegal meta data value: the child service doesn't exist”报错